### PR TITLE
[#16]  (재적용) 임베딩 파이프라인

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,40 +1,42 @@
 # ============================================
+# Application
+# ============================================
+SPRING_PROFILES_ACTIVE=local,api
+APP_PORT=8080
+FRONTEND_URL=http://localhost:5173
+
+# ============================================
 # Database (MySQL)
 # ============================================
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=pkv
 DB_USERNAME=root
-DB_PASSWORD=
+DB_PASSWORD=root
 
 # ============================================
-# Spring
-# ============================================
-SPRING_PROFILES_ACTIVE=local
-
-# ============================================
-# Application
-# ============================================
-APP_PORT=8080
-
-# ============================================
-# Monitoring (Prometheus + Grafana)
-# ============================================
-PROMETHEUS_PORT=9090
-GRAFANA_PORT=3000
-GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=admin
-
-# ============================================
-# OAuth2 (Google)
+# Auth (OAuth2 + JWT)
 # ============================================
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+JWT_SECRET=your-jwt-secret-key-minimum-32-characters-for-security
 
 # ============================================
-# JWT
+# Kafka
 # ============================================
-JWT_SECRET=your-jwt-secret-key-minimum-32-characters-for-security
+KAFKA_BOOTSTRAP_SERVERS=localhost:9094
+
+# ============================================
+# Qdrant (Vector DB)
+# ============================================
+QDRANT_HOST=localhost
+QDRANT_PORT=6334
+QDRANT_COLLECTION=pkv_text_segments
+
+# ============================================
+# OpenAI
+# ============================================
+OPENAI_API_KEY=your-openai-api-key
 
 # ============================================
 # AWS S3
@@ -45,6 +47,9 @@ AWS_ACCESS_KEY=your-aws-access-key
 AWS_SECRET_KEY=your-aws-secret-key
 
 # ============================================
-# Frontend
+# Monitoring (Prometheus + Grafana)
 # ============================================
-FRONTEND_URL=http://localhost:5173
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ out/
 
 ### Environment Variables ###
 .env
+.env.local
+frontend/.env.local
 
 .claude
 
@@ -42,3 +44,5 @@ out/
 
 frontend/tempdocs/
 tempdocs/
+
+dev/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ RUN chown -R appuser:appgroup /app
 
 USER appuser
 
+ENV SERVER_PORT=8080
+
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:${SERVER_PORT}/actuator/health || exit 1
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 - 멀티턴 대화를 통한 맥락 유지
 - 질문/답변 히스토리 관리
 
+## 로컬 실행
+
+- 환경 변수: `.env.local` (샘플은 `.env.example`)
+- 인프라 + 앱 실행:
+  ```bash
+  docker compose --profile infra --profile app up -d
+  ```
+- 모니터링 포함:
+  ```bash
+  docker compose --profile infra --profile app --profile monitoring up -d
+  ```
+
 ### 주요 컴포넌트
 
 | 컴포넌트          | 역할 |

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,16 @@ dependencies {
 
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // LangChain4j
+    implementation platform('dev.langchain4j:langchain4j-bom:1.11.0')
+    implementation 'dev.langchain4j:langchain4j'
+    implementation 'dev.langchain4j:langchain4j-open-ai-spring-boot-starter'
+    implementation 'dev.langchain4j:langchain4j-qdrant'
+    implementation 'dev.langchain4j:langchain4j-document-parser-apache-pdfbox'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // API Documentation
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,54 @@ services:
     networks:
       - pkv-network
 
+  kafka:
+    image: bitnamilegacy/kafka:3.7.1
+    container_name: pkv-kafka
+    restart: unless-stopped
+    profiles:
+      - infra
+    environment:
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    ports:
+      - "9094:9094"
+    volumes:
+      - kafka_data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - pkv-network
+
+  qdrant:
+    image: qdrant/qdrant:v1.13.2
+    container_name: pkv-qdrant
+    restart: unless-stopped
+    profiles:
+      - infra
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/6333'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - pkv-network
+
   app:
     build: .
     container_name: pkv-app
@@ -37,13 +85,41 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      kafka:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    env_file: .env.local
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${DB_NAME:-pkv}
-      SPRING_DATASOURCE_USERNAME: root
-      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD:-root}
+      SPRING_PROFILES_ACTIVE: local,api
+      DB_HOST: mysql
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      QDRANT_HOST: qdrant
     ports:
       - "${APP_PORT:-8080}:8080"
+    networks:
+      - pkv-network
+
+  worker:
+    build: .
+    container_name: pkv-worker
+    restart: unless-stopped
+    profiles:
+      - app
+    depends_on:
+      mysql:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    env_file: .env.local
+    environment:
+      SPRING_PROFILES_ACTIVE: local,worker
+      SERVER_PORT: 8081
+      DB_HOST: mysql
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      QDRANT_HOST: qdrant
     networks:
       - pkv-network
 
@@ -89,14 +165,11 @@ services:
 
 volumes:
   mysql_data:
+  kafka_data:
+  qdrant_data:
   prometheus_data:
   grafana_data:
 
 networks:
   pkv-network:
     driver: bridge
-
-# redis:     # 시맨틱 캐싱 - 캐싱 기능 구현 시 추가
-# qdrant:    # 벡터 DB - RAG 기능 구현 시 추가
-# zookeeper: # Kafka 코디네이션 - 비동기 처리 구현 시 추가
-# kafka:     # 메시지 큐 - 비동기 처리 구현 시 추가

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -10,4 +10,9 @@ scrape_configs:
   - job_name: 'pkv-app'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets: ['pkv-app:8080']
+
+  - job_name: 'pkv-worker'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['pkv-worker:8081']

--- a/src/main/java/com/pkv/auth/config/SecurityConfig.java
+++ b/src/main/java/com/pkv/auth/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -31,6 +32,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@Profile("api")
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;

--- a/src/main/java/com/pkv/auth/controller/AuthController.java
+++ b/src/main/java/com/pkv/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Profile("api")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/pkv/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pkv/auth/jwt/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,6 +21,7 @@ import java.util.Collections;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("api")
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/pkv/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/pkv/auth/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -12,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
+@Profile("api")
 public class JwtTokenProvider {
 
     private static final String TOKEN_TYPE_CLAIM = "type";

--- a/src/main/java/com/pkv/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/pkv/auth/oauth2/CustomOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.pkv.auth.oauth2;
 import com.pkv.member.domain.Member;
 import com.pkv.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -18,6 +19,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Profile("api")
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/com/pkv/auth/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/pkv/auth/oauth2/OAuth2FailureHandler.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
@@ -18,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("api")
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/pkv/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pkv/auth/oauth2/OAuth2SuccessHandler.java
@@ -6,6 +6,7 @@ import com.pkv.auth.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@Profile("api")
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -22,7 +24,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     public OAuth2SuccessHandler(
             JwtTokenProvider jwtTokenProvider,
-            @Value("${app.frontend-url:http://localhost:5173}") String frontendUrl) {
+            @Value("${app.frontend-url}") String frontendUrl) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.frontendUrl = frontendUrl;
     }

--- a/src/main/java/com/pkv/auth/service/AuthService.java
+++ b/src/main/java/com/pkv/auth/service/AuthService.java
@@ -8,12 +8,14 @@ import com.pkv.common.exception.PkvException;
 import com.pkv.member.domain.Member;
 import com.pkv.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Profile("api")
 public class AuthService {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/com/pkv/chat/controller/ChatController.java
+++ b/src/main/java/com/pkv/chat/controller/ChatController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
+@Profile("api")
 public class ChatController {
 
     private final MockChatService chatService;

--- a/src/main/java/com/pkv/common/config/KafkaConstants.java
+++ b/src/main/java/com/pkv/common/config/KafkaConstants.java
@@ -1,0 +1,10 @@
+package com.pkv.common.config;
+
+public final class KafkaConstants {
+
+    public static final String EMBEDDING_JOB_TOPIC = "embedding-job";
+    public static final String EMBEDDING_CONTAINER_FACTORY = "embeddingKafkaListenerContainerFactory";
+
+    private KafkaConstants() {
+    }
+}

--- a/src/main/java/com/pkv/common/config/OpenApiConfig.java
+++ b/src/main/java/com/pkv/common/config/OpenApiConfig.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("api")
 public class OpenApiConfig {
     @Bean
     public OpenAPI pkvOpenAPI() {

--- a/src/main/java/com/pkv/common/config/QdrantConfig.java
+++ b/src/main/java/com/pkv/common/config/QdrantConfig.java
@@ -1,0 +1,50 @@
+package com.pkv.common.config;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class QdrantConfig {
+
+    private static final int VECTOR_DIMENSION = 1536;
+
+    @Bean
+    public EmbeddingStore<TextSegment> embeddingStore(
+            @Value("${qdrant.host}") String host,
+            @Value("${qdrant.port}") int port,
+            @Value("${qdrant.collection-name}") String collectionName) {
+        ensureCollectionExists(host, port, collectionName);
+        return QdrantEmbeddingStore.builder()
+                .host(host)
+                .port(port)
+                .collectionName(collectionName)
+                .build();
+    }
+
+    private void ensureCollectionExists(String host, int port, String collectionName) {
+        try (QdrantClient client = new QdrantClient(
+                QdrantGrpcClient.newBuilder(host, port, false).build())) {
+            if (!client.collectionExistsAsync(collectionName).get()) {
+                client.createCollectionAsync(collectionName,
+                        VectorParams.newBuilder()
+                                .setSize(VECTOR_DIMENSION)
+                                .setDistance(Distance.Cosine)
+                                .build()
+                ).get();
+                log.info("Qdrant 컬렉션 '{}' 생성 완료", collectionName);
+            }
+        } catch (Exception e) {
+            log.warn("Qdrant 컬렉션 초기화 실패 — Qdrant가 실행 중인지 확인하세요: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/pkv/common/config/WorkerSecurityConfig.java
+++ b/src/main/java/com/pkv/common/config/WorkerSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.pkv.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@Profile("worker")
+public class WorkerSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain workerSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().denyAll())
+                .build();
+    }
+}

--- a/src/main/java/com/pkv/common/exception/ErrorCode.java
+++ b/src/main/java/com/pkv/common/exception/ErrorCode.java
@@ -30,7 +30,12 @@ public enum ErrorCode {
     SOURCE_TOTAL_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "S006", "총 저장 용량 300MB를 초과합니다."),
     SOURCE_NAME_DUPLICATED(HttpStatus.CONFLICT, "S007", "동일한 이름의 파일이 이미 존재합니다."),
     SOURCE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "S008", "현재 상태에서는 삭제할 수 없습니다."),
-    SOURCE_UPLOAD_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "S009", "파일 업로드가 확인되지 않았습니다.");
+    SOURCE_UPLOAD_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "S009", "파일 업로드가 확인되지 않았습니다."),
+
+    // 임베딩 파이프라인(파싱/청킹/임베딩)
+    DOCUMENT_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "W001", "문서 파싱에 실패했습니다."),
+    EMBEDDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "W002", "임베딩 처리에 실패했습니다."),
+    EMBEDDING_JOB_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "W003", "임베딩 작업 메시지 발행에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/pkv/common/service/EmbeddingRepository.java
+++ b/src/main/java/com/pkv/common/service/EmbeddingRepository.java
@@ -1,0 +1,24 @@
+package com.pkv.common.service;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class EmbeddingRepository {
+
+    private final EmbeddingStore<TextSegment> embeddingStore;
+
+    public void deleteBySourceId(Long sourceId) {
+        Filter filter = metadataKey("sourceId").isEqualTo(sourceId);
+        embeddingStore.removeAll(filter);
+        log.info("벡터 삭제 완료: sourceId={}", sourceId);
+    }
+}

--- a/src/main/java/com/pkv/history/controller/HistoryController.java
+++ b/src/main/java/com/pkv/history/controller/HistoryController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/history")
 @RequiredArgsConstructor
+@Profile("api")
 public class HistoryController {
 
     private final MockHistoryService historyService;

--- a/src/main/java/com/pkv/member/controller/MemberController.java
+++ b/src/main/java/com/pkv/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Profile("api")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/pkv/source/controller/SourceController.java
+++ b/src/main/java/com/pkv/source/controller/SourceController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/sources")
 @RequiredArgsConstructor
+@Profile("api")
 public class SourceController {
 
     private final SourceService sourceService;

--- a/src/main/java/com/pkv/source/domain/Source.java
+++ b/src/main/java/com/pkv/source/domain/Source.java
@@ -68,6 +68,30 @@ public class Source {
         this.updatedAt = Instant.now();
     }
 
+    public void startProcessing() {
+        if (this.status != SourceStatus.UPLOADED) {
+            throw new IllegalStateException("Source can only start processing from UPLOADED status, current: " + this.status);
+        }
+        this.status = SourceStatus.PROCESSING;
+        this.updatedAt = Instant.now();
+    }
+
+    public void complete() {
+        if (this.status != SourceStatus.PROCESSING) {
+            throw new IllegalStateException("Source can only be completed from PROCESSING status, current: " + this.status);
+        }
+        this.status = SourceStatus.COMPLETED;
+        this.updatedAt = Instant.now();
+    }
+
+    public void fail() {
+        if (this.status != SourceStatus.PROCESSING) {
+            throw new IllegalStateException("Source can only fail from PROCESSING status, current: " + this.status);
+        }
+        this.status = SourceStatus.FAILED;
+        this.updatedAt = Instant.now();
+    }
+
     public boolean isDeletable() {
         return this.status == SourceStatus.COMPLETED || this.status == SourceStatus.FAILED;
     }

--- a/src/main/java/com/pkv/source/dto/EmbeddingJobMessage.java
+++ b/src/main/java/com/pkv/source/dto/EmbeddingJobMessage.java
@@ -1,0 +1,10 @@
+package com.pkv.source.dto;
+
+public record EmbeddingJobMessage(
+        Long sourceId,
+        Long memberId,
+        String storagePath,
+        String originalFileName,
+        String fileExtension
+) {
+}

--- a/src/main/java/com/pkv/source/service/EmbeddingJobProducer.java
+++ b/src/main/java/com/pkv/source/service/EmbeddingJobProducer.java
@@ -1,0 +1,50 @@
+package com.pkv.source.service;
+
+import com.pkv.common.config.KafkaConstants;
+import com.pkv.common.exception.ErrorCode;
+import com.pkv.common.exception.PkvException;
+import com.pkv.source.domain.Source;
+import com.pkv.source.dto.EmbeddingJobMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+@Service
+@Profile("api")
+@RequiredArgsConstructor
+public class EmbeddingJobProducer {
+
+    private final KafkaTemplate<String, EmbeddingJobMessage> kafkaTemplate;
+
+    public void send(Source source) {
+        EmbeddingJobMessage message = new EmbeddingJobMessage(
+                source.getId(),
+                source.getMemberId(),
+                source.getStoragePath(),
+                source.getOriginalFileName(),
+                source.getFileExtension()
+        );
+
+        try {
+            kafkaTemplate.send(
+                    KafkaConstants.EMBEDDING_JOB_TOPIC,
+                    source.getId().toString(),
+                    message
+            ).get(5, TimeUnit.SECONDS);
+
+            log.info("임베딩 작업 메시지 발행 완료: sourceId={}", source.getId());
+        } catch (ExecutionException | TimeoutException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PkvException(ErrorCode.EMBEDDING_JOB_PUBLISH_FAILED, e);
+        }
+    }
+}

--- a/src/main/java/com/pkv/source/service/S3FileStorage.java
+++ b/src/main/java/com/pkv/source/service/S3FileStorage.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -58,6 +59,15 @@ public class S3FileStorage {
         } catch (NoSuchKeyException e) {
             return false;
         }
+    }
+
+    /**
+     * 현재 파일 크기 제한: 30MB
+     */
+    public byte[] downloadObject(String key) {
+        return s3Client.getObjectAsBytes(
+                GetObjectRequest.builder().bucket(bucket).key(key).build()
+        ).asByteArray();
     }
 
     public void deleteObject(String key) {

--- a/src/main/java/com/pkv/source/service/SourceService.java
+++ b/src/main/java/com/pkv/source/service/SourceService.java
@@ -7,8 +7,10 @@ import com.pkv.source.domain.SourceStatus;
 import com.pkv.source.dto.PresignRequest;
 import com.pkv.source.dto.PresignResponse;
 import com.pkv.source.dto.SourceResponse;
+import com.pkv.common.service.EmbeddingRepository;
 import com.pkv.source.repository.SourceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
+@Profile("api")
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SourceService {
@@ -23,6 +26,8 @@ public class SourceService {
     private final SourceRepository sourceRepository;
     private final SourceValidator sourceValidator;
     private final S3FileStorage s3FileStorage;
+    private final EmbeddingJobProducer embeddingJobProducer;
+    private final EmbeddingRepository embeddingRepository;
 
     @Transactional
     public PresignResponse requestPresignedUrl(Long memberId, PresignRequest request) {
@@ -91,6 +96,7 @@ public class SourceService {
         }
 
         source.confirm();
+        embeddingJobProducer.send(source);
 
         return SourceResponse.from(source);
     }
@@ -103,6 +109,8 @@ public class SourceService {
         if (!source.isDeletable()) {
             throw new PkvException(ErrorCode.SOURCE_DELETE_NOT_ALLOWED);
         }
+
+        embeddingRepository.deleteBySourceId(sourceId);
 
         s3FileStorage.deleteObject(source.getStoragePath());
         sourceRepository.delete(source);

--- a/src/main/java/com/pkv/worker/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/pkv/worker/config/KafkaConsumerConfig.java
@@ -1,0 +1,40 @@
+package com.pkv.worker.config;
+
+import com.pkv.worker.consumer.EmbeddingPipelineErrorHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+@Configuration
+@Profile("worker")
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    private final EmbeddingPipelineErrorHandler embeddingPipelineErrorHandler;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<?, ?> embeddingKafkaListenerContainerFactory(
+            ConcurrentKafkaListenerContainerFactoryConfigurer configurer,
+            ConsumerFactory<Object, Object> consumerFactory) {
+
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        configurer.configure(factory, consumerFactory);
+
+        ExponentialBackOff exponentialBackOff = new ExponentialBackOff(1000L, 2.0);
+        exponentialBackOff.setMaxAttempts(2);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+                embeddingPipelineErrorHandler::recoverFailedEmbedding,
+                exponentialBackOff
+        );
+        factory.setCommonErrorHandler(errorHandler);
+
+        return factory;
+    }
+}

--- a/src/main/java/com/pkv/worker/consumer/EmbeddingPipelineConsumer.java
+++ b/src/main/java/com/pkv/worker/consumer/EmbeddingPipelineConsumer.java
@@ -1,0 +1,70 @@
+package com.pkv.worker.consumer;
+
+import com.pkv.common.config.KafkaConstants;
+import com.pkv.source.domain.Source;
+import com.pkv.source.domain.SourceStatus;
+import com.pkv.source.repository.SourceRepository;
+import com.pkv.worker.dto.ChunkedDocument;
+import com.pkv.source.dto.EmbeddingJobMessage;
+import com.pkv.worker.dto.ParsedDocument;
+import com.pkv.common.service.EmbeddingRepository;
+import com.pkv.worker.service.DocumentParser;
+import com.pkv.worker.service.EmbeddingService;
+import com.pkv.worker.service.TextChunker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("worker")
+@RequiredArgsConstructor
+public class EmbeddingPipelineConsumer {
+
+    private final SourceRepository sourceRepository;
+    private final EmbeddingRepository embeddingRepository;
+    private final DocumentParser documentParser;
+    private final TextChunker textChunker;
+    private final EmbeddingService embeddingService;
+
+    @KafkaListener(
+            topics = KafkaConstants.EMBEDDING_JOB_TOPIC,
+            containerFactory = KafkaConstants.EMBEDDING_CONTAINER_FACTORY
+    )
+    public void consume(EmbeddingJobMessage message) {
+        log.info("임베딩 작업 수신: sourceId={}", message.sourceId());
+
+        Source source = sourceRepository.findById(message.sourceId()).orElse(null);
+        if (source == null) {
+            log.warn("Source를 찾을 수 없음: sourceId={}", message.sourceId());
+            return;
+        }
+
+        if (source.getStatus() == SourceStatus.UPLOADED) {
+            source.startProcessing();
+            sourceRepository.save(source);
+        } else if (source.getStatus() != SourceStatus.PROCESSING) {
+            log.info("이미 처리된 Source, 건너뜀: sourceId={}, status={}", message.sourceId(), source.getStatus());
+            return;
+        }
+
+        executePipeline(message);
+
+        source.complete();
+        sourceRepository.save(source);
+        log.info("임베딩 파이프라인 완료: sourceId={}", message.sourceId());
+    }
+
+    private void executePipeline(EmbeddingJobMessage message) {
+        embeddingRepository.deleteBySourceId(message.sourceId());
+
+        ParsedDocument parsed = documentParser.parse(message.storagePath(), message.fileExtension());
+
+        ChunkedDocument chunked = textChunker.chunk(
+                parsed, message.sourceId(), message.memberId(), message.originalFileName());
+
+        embeddingService.embed(chunked);
+    }
+}

--- a/src/main/java/com/pkv/worker/consumer/EmbeddingPipelineErrorHandler.java
+++ b/src/main/java/com/pkv/worker/consumer/EmbeddingPipelineErrorHandler.java
@@ -1,0 +1,33 @@
+package com.pkv.worker.consumer;
+
+import com.pkv.source.dto.EmbeddingJobMessage;
+import com.pkv.source.repository.SourceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("worker")
+@RequiredArgsConstructor
+public class EmbeddingPipelineErrorHandler {
+
+    private final SourceRepository sourceRepository;
+
+    public void recoverFailedEmbedding(ConsumerRecord<?, ?> record, Exception exception) {
+        EmbeddingJobMessage message = (EmbeddingJobMessage) record.value();
+        log.error("임베딩 파이프라인 재시도 소진: sourceId={}", message.sourceId(), exception);
+
+        sourceRepository.findById(message.sourceId()).ifPresent(source -> {
+            try {
+                source.fail();
+            } catch (IllegalStateException ignored) {
+                return;
+            }
+            sourceRepository.save(source);
+            log.info("Source 상태를 FAILED로 변경: sourceId={}", message.sourceId());
+        });
+    }
+}

--- a/src/main/java/com/pkv/worker/dto/ChunkedDocument.java
+++ b/src/main/java/com/pkv/worker/dto/ChunkedDocument.java
@@ -1,0 +1,15 @@
+package com.pkv.worker.dto;
+
+import java.util.List;
+
+public record ChunkedDocument(
+        List<Chunk> chunks
+) {
+    public record Chunk(
+            String text,
+            Long sourceId,
+            Long memberId,
+            String fileName,
+            int pageNumber
+    ) {}
+}

--- a/src/main/java/com/pkv/worker/dto/ParsedDocument.java
+++ b/src/main/java/com/pkv/worker/dto/ParsedDocument.java
@@ -1,0 +1,10 @@
+package com.pkv.worker.dto;
+
+import java.util.List;
+
+public record ParsedDocument(
+        String fullText,
+        List<PageOffset> pageOffsets
+) {
+    public record PageOffset(int pageNumber, int startOffset) {}
+}

--- a/src/main/java/com/pkv/worker/service/DocumentParser.java
+++ b/src/main/java/com/pkv/worker/service/DocumentParser.java
@@ -1,0 +1,79 @@
+package com.pkv.worker.service;
+
+import com.pkv.common.exception.ErrorCode;
+import com.pkv.common.exception.PkvException;
+import com.pkv.source.service.S3FileStorage;
+import com.pkv.worker.dto.ParsedDocument;
+import com.pkv.worker.dto.ParsedDocument.PageOffset;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("worker")
+@RequiredArgsConstructor
+public class DocumentParser {
+
+    private final S3FileStorage s3FileStorage;
+
+    public ParsedDocument parse(String storagePath, String fileExtension) {
+        byte[] bytes = s3FileStorage.downloadObject(storagePath);
+
+        return switch (fileExtension.toLowerCase()) {
+            case "pdf" -> parsePdf(bytes);
+            case "txt", "md" -> parsePlainText(bytes);
+            default -> throw new PkvException(ErrorCode.DOCUMENT_PARSE_FAILED,
+                    "지원하지 않는 파일 형식: " + fileExtension);
+        };
+    }
+
+    private ParsedDocument parsePdf(byte[] bytes) {
+        try (PDDocument document = PDDocument.load(bytes)) {
+            int pageCount = document.getNumberOfPages();
+            if (pageCount == 0) {
+                throw new PkvException(ErrorCode.DOCUMENT_PARSE_FAILED, "PDF에 페이지가 없습니다.");
+            }
+
+            StringBuilder fullText = new StringBuilder();
+            List<PageOffset> pageOffsets = new ArrayList<>();
+            PDFTextStripper stripper = new PDFTextStripper();
+
+            for (int i = 1; i <= pageCount; i++) {
+                stripper.setStartPage(i);
+                stripper.setEndPage(i);
+
+                int startOffset = fullText.length();
+                pageOffsets.add(new PageOffset(i, startOffset));
+
+                String pageText = stripper.getText(document);
+                fullText.append(pageText);
+            }
+
+            // 스캔 이미지만 있는 PDF 등 텍스트가 없는 경우
+            // TODO: OCR 기능 추가
+            if (fullText.toString().isBlank()) {
+                throw new PkvException(ErrorCode.DOCUMENT_PARSE_FAILED, "PDF에서 텍스트를 추출할 수 없습니다.");
+            }
+
+            return new ParsedDocument(fullText.toString(), pageOffsets);
+        } catch (PkvException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new PkvException(ErrorCode.DOCUMENT_PARSE_FAILED, e);
+        }
+    }
+
+    private ParsedDocument parsePlainText(byte[] bytes) {
+        String text = new String(bytes, StandardCharsets.UTF_8);
+        if (text.trim().isEmpty()) {
+            throw new PkvException(ErrorCode.DOCUMENT_PARSE_FAILED, "파일이 비어있습니다.");
+        }
+        return new ParsedDocument(text, List.of(new PageOffset(1, 0)));
+    }
+}

--- a/src/main/java/com/pkv/worker/service/EmbeddingService.java
+++ b/src/main/java/com/pkv/worker/service/EmbeddingService.java
@@ -1,0 +1,53 @@
+package com.pkv.worker.service;
+
+import com.pkv.common.exception.ErrorCode;
+import com.pkv.common.exception.PkvException;
+import com.pkv.worker.dto.ChunkedDocument;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Profile("worker")
+@RequiredArgsConstructor
+public class EmbeddingService {
+
+    private final EmbeddingModel embeddingModel;
+
+    private final EmbeddingStore<TextSegment> embeddingStore;
+
+    public void embed(ChunkedDocument chunkedDocument) {
+        List<TextSegment> segments = chunkedDocument.chunks().stream()
+                .map(this::toTextSegment)
+                .toList();
+
+        try {
+            // TODO: 문서 크기가 커질 경우 embedAll/addAll을 코드 레벨에서 고정 크기 분할 처리 검토
+            Response<List<Embedding>> response = embeddingModel.embedAll(segments);
+            List<Embedding> embeddings = response.content();
+            embeddingStore.addAll(embeddings, segments);
+            log.info("임베딩 완료: {}개 청크 처리", segments.size());
+        } catch (Exception e) {
+            throw new PkvException(ErrorCode.EMBEDDING_FAILED, e);
+        }
+    }
+
+    private TextSegment toTextSegment(ChunkedDocument.Chunk chunk) {
+        Metadata metadata = new Metadata()
+                .put("memberId", chunk.memberId())
+                .put("sourceId", chunk.sourceId())
+                .put("fileName", chunk.fileName())
+                .put("pageNumber", chunk.pageNumber());
+        return TextSegment.from(chunk.text(), metadata);
+    }
+}

--- a/src/main/java/com/pkv/worker/service/TextChunker.java
+++ b/src/main/java/com/pkv/worker/service/TextChunker.java
@@ -1,0 +1,72 @@
+package com.pkv.worker.service;
+
+import com.pkv.worker.dto.ChunkedDocument;
+import com.pkv.worker.dto.ChunkedDocument.Chunk;
+import com.pkv.worker.dto.ParsedDocument;
+import com.pkv.worker.dto.ParsedDocument.PageOffset;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("worker")
+public class TextChunker {
+
+    private final DocumentSplitter splitter;
+
+    public TextChunker(
+            @Value("${pkv.chunking.max-tokens:512}") int maxTokens,
+            @Value("${pkv.chunking.overlap-tokens:64}") int overlapTokens,
+            @Value("${langchain4j.open-ai.embedding-model.model-name}") String embeddingModelName) {
+        this.splitter = DocumentSplitters.recursive(
+                maxTokens, overlapTokens, new OpenAiTokenCountEstimator(embeddingModelName)
+        );
+    }
+    
+    public ChunkedDocument chunk(ParsedDocument parsedDocument, Long sourceId, Long memberId,
+                                  String fileName) {
+        Document document = Document.from(parsedDocument.fullText());
+        List<TextSegment> segments = splitter.split(document);
+
+        List<Chunk> chunks = new ArrayList<>();
+        int searchFrom = 0;
+        for (TextSegment segment : segments) {
+            String segmentText = segment.text();
+
+            int charOffset = findCharOffset(parsedDocument.fullText(), segmentText, searchFrom);
+            int pageNumber = resolvePageNumber(parsedDocument.pageOffsets(), charOffset);
+
+            if (charOffset >= 0) {
+                searchFrom = charOffset + 1;
+            }
+
+            chunks.add(new Chunk(segmentText, sourceId, memberId, fileName, pageNumber));
+        }
+
+        return new ChunkedDocument(chunks);
+    }
+
+    private int findCharOffset(String fullText, String segmentText, int searchFrom) {
+        int charOffset = fullText.indexOf(segmentText, searchFrom);
+        return charOffset >= 0 ? charOffset : fullText.indexOf(segmentText);
+    }
+
+    private int resolvePageNumber(List<PageOffset> pageOffsets, int charOffset) {
+        if (charOffset < 0) {
+            return pageOffsets.getLast().pageNumber();
+        }
+
+        return pageOffsets.stream()
+                .filter(page -> page.startOffset() <= charOffset)
+                .reduce((previous, current) -> current)
+                .map(PageOffset::pageNumber)
+                .orElse(pageOffsets.getFirst().pageNumber());
+    }
+}

--- a/src/main/resources/application-api.yml
+++ b/src/main/resources/application-api.yml
@@ -1,0 +1,26 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    listener:
+      auto-startup: false
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiry: 1800000
+  refresh-token-expiry: 604800000
+
+app:
+  frontend-url: ${FRONTEND_URL:http://localhost:5173}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,5 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/main/resources/application-worker.yml
+++ b/src/main/resources/application-worker.yml
@@ -1,0 +1,17 @@
+server:
+  port: 8081
+
+spring:
+  kafka:
+    consumer:
+      group-id: pkv-embedding-worker
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: com.pkv.*
+
+pkv:
+  chunking:
+    max-tokens: 512
+    overlap-tokens: 64

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,21 +2,10 @@ spring:
   application:
     name: pkv
 
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_SECRET}
-            scope:
-              - email
-              - profile
-
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:pkv}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:}
+    password: ${DB_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -25,8 +14,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
-    show-sql: true
+        format_sql: false
+    show-sql: false
     open-in-view: false
 
   flyway:
@@ -34,9 +23,20 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true
 
-logging:
-  level:
-    com.pkv: DEBUG
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9094}
+
+langchain4j:
+  open-ai:
+    embedding-model:
+      api-key: ${OPENAI_API_KEY:}
+      model-name: text-embedding-3-small
+
+
+qdrant:
+  host: ${QDRANT_HOST:localhost}
+  port: ${QDRANT_PORT:6334}
+  collection-name: ${QDRANT_COLLECTION:pkv_text_segments}
 
 management:
   endpoints:
@@ -51,14 +51,6 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
-
-jwt:
-  secret: ${JWT_SECRET:pkv-dev-only-jwt-secret-key-do-not-use-in-production-a1b2c3d4e5f6}
-  access-token-expiry: 1800000
-  refresh-token-expiry: 604800000
-
-app:
-  frontend-url: ${FRONTEND_URL:http://localhost:5173}
 
 cloud:
   aws:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -14,6 +14,7 @@
             <appender-ref ref="CONSOLE"/>
         </root>
         <logger name="com.pkv" level="DEBUG"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
     </springProfile>
 
     <springProfile name="!local,!test">
@@ -22,8 +23,6 @@
         </root>
         <logger name="com.pkv" level="INFO"/>
     </springProfile>
-
-    <logger name="org.hibernate.SQL" level="DEBUG"/>
 
     <logger name="org.testcontainers" level="INFO"/>
 

--- a/src/test/java/com/pkv/PkvApplicationTests.java
+++ b/src/test/java/com/pkv/PkvApplicationTests.java
@@ -1,12 +1,9 @@
 package com.pkv;
 
+import com.pkv.support.IntegrationTestSupport;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class PkvApplicationTests {
+class PkvApplicationTests extends IntegrationTestSupport {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/pkv/auth/config/SecurityConfigIntegrationTest.java
+++ b/src/test/java/com/pkv/auth/config/SecurityConfigIntegrationTest.java
@@ -1,11 +1,10 @@
 package com.pkv.auth.config;
 
+import com.pkv.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,10 +12,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-class SecurityConfigIntegrationTest {
+class SecurityConfigIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/pkv/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/pkv/auth/controller/AuthControllerIntegrationTest.java
@@ -3,15 +3,14 @@ package com.pkv.auth.controller;
 import com.pkv.auth.jwt.JwtTokenProvider;
 import com.pkv.member.domain.Member;
 import com.pkv.member.repository.MemberRepository;
+import com.pkv.support.IntegrationTestSupport;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,11 +21,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class AuthControllerIntegrationTest {
+class AuthControllerIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/pkv/support/IntegrationTestSupport.java
+++ b/src/test/java/com/pkv/support/IntegrationTestSupport.java
@@ -1,0 +1,19 @@
+package com.pkv.support;
+
+import com.pkv.source.service.EmbeddingJobProducer;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles({"api", "test"})
+public abstract class IntegrationTestSupport {
+
+    @MockitoBean
+    protected EmbeddingJobProducer embeddingJobProducer;
+
+    @MockitoBean
+    protected EmbeddingStore<TextSegment> embeddingStore;
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,9 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - dev.langchain4j.openai.spring.AutoConfig
+
   security:
     oauth2:
       client:
@@ -25,11 +30,6 @@ spring:
 
 jwt:
   secret: test-jwt-secret-key-for-testing-purposes-only-32-chars-minimum
-  access-token-expiry: 1800000
-  refresh-token-expiry: 604800000
-
-app:
-  frontend-url: http://localhost:5173
 
 cloud:
   aws:
@@ -39,3 +39,6 @@ cloud:
     credentials:
       access-key: mock-access-key
       secret-key: mock-secret-key
+
+qdrant:
+  collection-name: test_vectors


### PR DESCRIPTION
- Spring AI 제거하고 LangChain4J 으로 전환
  - Spring AI가 text splitting 과정에서 오버랩을 지원하지 않아 교체했습니다.

- Kafka + worker 비동기 임베딩 파이프라인 추가
  - Worker 문서 처리 흐름: S3 다운로드 → 파싱(PDF/TXT/MD) → 청킹 → OpenAI 임베딩 → Qdrant 저장

- Source 삭제 시 벡터 임베딩 정리 로직 추가 (S3/DB 삭제와 함께 처리)

- api/worker 프로파일 및 설정 분리